### PR TITLE
Fixed confusion of Ubuntu versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note: you need to *log in and out* to have the group change take effect.
 
 ### Installation on Ubuntu 16.xx
 
-As for ubuntu 18, run:
+As for ubuntu 16, run:
 
     $ sudo apt install -y git git-lfs
     


### PR DESCRIPTION
On the header the section is talking about installation for Ubuntu 16.xx, but in the body text it is referring back to 18 version. This seems to be a typo and should be referring as Ubuntu 16.