### PR TITLE
Updated doc + vscode profile + minor setup.py fix

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,21 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-python.python",
+		"ms-python.debugpy",
+		"ms-python.vscode-pylance",
+		"mads-hartmann.bash-ide-vscode",
+		"editorconfig.editorconfig",
+		"ms-azuretools.vscode-docker",
+		"marlom.keep-context",
+		"njpwerner.autodocstring",
+		"charliermarsh.ruff"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "dts",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "dt_shell_cli.dts",
+            "console": "integratedTerminal",
+            "args": "${command:pickArgs}"
+        },
+    ]
+}

--- a/.vscode/python.env
+++ b/.vscode/python.env
@@ -1,0 +1,7 @@
+# Python runtime environment variables
+
+PYTHONPATH=./lib
+
+# DTSHELL_VENV_DIR=.venv/
+
+# DTSHELL_COMMANDS=./duckietown-shell-commands

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.envFile": "${workspaceFolder}/.vscode/python.env",
+    "editor.wordWrapColumn": 120,
+    "editor.rulers": [
+        120
+    ],
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/duckietown/duckietown-shell.svg?style=shield)](https://circleci.com/gh/duckietown/duckietown-shell) 
+[![CircleCI](https://circleci.com/gh/duckietown/duckietown-shell.svg?style=shield)](https://circleci.com/gh/duckietown/duckietown-shell)
 [![Docker Hub](https://img.shields.io/docker/pulls/duckietown/duckietown-shell.svg)](https://hub.docker.com/r/duckietown/duckietown-shell/)
 
 # Duckietown Shell
@@ -8,81 +8,25 @@
 The idea is that most of the functionality is implemented as Docker containers, and `dt-shell` provides a nice interface for that, so that user should not type a very long `docker run` command line.
 
 **Note: Duckietown Shell required Python 3.6 or higher.**
- 
+
 ## Prerequisites
 
-The duckietown shell has very minimal requirements. 
+The duckietown shell has very minimal requirements.
 Please use the links provided and follow the instructions for your OS
 
 1. [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git/)
 2. [Git LFS](https://git-lfs.github.com/) (for building and working with the docs only)
-2. [Docker](https://docs.docker.com/get-docker/)
+3. [Docker](https://docs.docker.com/get-docker/)
 
-## Installing the Duckietown Shell
+### Docker Prerequisites
 
-### Installation on Ubuntu 18.xx or 20.xx
-
-**Note**: This OS is officially supported
-
-Install `pip3`
-
-    $ sudo apt install -y python3-pip
-    
-Add yourself to the `docker` group:
+**Note**: You need to add yourself to the `docker` group:
 
     $ sudo adduser `whoami` docker
 
-**Note**: you may need to *log in and out* to have the group change take effect.
+**Important**: after you that, you must *log out and in* to have the group change take effect.
 
-Install the `duckietown-shell` Python package:
-
-    $ pip3 install --no-cache-dir --user -U duckietown-shell
-
-
-#### Testing the Installation
-
-Typing 
-
-    $ which dts
-    
-should output something like: `/home/![user]/.local/bin/dts`
-
-If nothing is output you may need to add `/home/![user]/.local/bin` to your shell path. You can do so by adding the line:
-
-    `export PATH=$PATH:/root/.local/bin`
-    
-into your `~/.bashrc` file (if you use bash, otherwise the corresponding shell initialization file).
-
-### Installation on Ubuntu 16.xx
-
-The duckietown shell requires python 3.6 or higher, which is not standard on ubuntu16.
-A currently working workaround is to install homebrew, by following instructions [here](https://docs.brew.sh/Homebrew-on-Linux). 
-Then, run :
-
-    $ brew install python3
-    $ python3.7 -m pip install --no-cache-dir --user -U duckietown-shell
-
-Then, typing 
-
-    $ which dts
-
-should output : `/home/linuxbrew/.linuxbrew/bin/dts`
-
-### OS X
-
-[Install `pip3`](https://evansdianga.com/install-pip-osx/).
-    
-Add yourself to the `docker` group:
-
-    $ sudo adduser `whoami` docker
-
-Install the `duckietown-shell`:
-
-**Note: Never use `sudo pip install` to install `duckietown-shell`.**
-
-    $ pip3 install --no-cache-dir --user -U duckietown-shell
-
-Note: you may need to *log in and out* to have the group change take effect.
+#### Docker on MacOS
 
 By default Docker uses the OS X keychain to store credentials but this is not good.
 
@@ -100,15 +44,103 @@ Then you should see an `auth` entry of the type:
         },
     }
 
+## Installing the Duckietown Shell
+
+### Installation on Ubuntu 18.xx or 20.xx
+
+**Note**: This OS is officially supported
+
+#### Install using [pipx](https://pipx.pypa.io/stable/installation/)
+
+Install `pipx`:
+
+    $ sudo apt install -y pipx
+
+Install the `duckietown-shell`:
+
+    $ pipx install duckietown-shell
+
+To upgrade to the latest version of `duckietown-sheel`:
+
+    $ pipx upgrade duckietown-shell
+
+#### Install using `pip`
+
+Install `pip3`
+
+    $ sudo apt install -y python3-pip
+
+Install the `duckietown-shell` Python package:
+
+    $ pip3 install --no-cache-dir --user -U duckietown-shell
+
+#### Testing the Installation on Ubuntu
+
+Typing
+
+    $ which dts
+
+should output something like: `/home/![user]/.local/bin/dts`
+
+If nothing is output you may need to add `/home/![user]/.local/bin` to your shell path. You can do so by adding the line:
+
+    `export PATH=$PATH:/root/.local/bin`
+
+into your `~/.bashrc` file (if you use bash, otherwise the corresponding shell initialization file).
+
+### Installation on Ubuntu 16.xx
+
+The duckietown shell requires python 3.6 or higher, which is not standard on ubuntu16.
+A currently working workaround is to install homebrew, by following instructions [here](https://docs.brew.sh/Homebrew-on-Linux).
+Then, run :
+
+    $ brew install python3
+    $ python3.7 -m pip install --no-cache-dir --user -U duckietown-shell
+
+Then, typing
+
+    $ which dts
+
+should output : `/home/linuxbrew/.linuxbrew/bin/dts`
+
+### Duckietown Shell on MacOS X
+
+#### Using `pipx` to install
+
+Install `pipx`:
+
+(see https://pipx.pypa.io/stable/installation/ for more details)
+
+    $ brew install pipx
+    $ pipx ensurepath
+    $ sudo pipx ensurepath --global # optional to allow pipx actions in global scope. See "Global installation" section below.
+
+Install the `duckietown-shell`:
+
+    $ pipx install duckietown-shell
+
+To upgrade to the latest version of `duckietown-sheel`:
+
+    $ pipx upgrade duckietown-shell
+
+#### Using `pip` to install
+
+[Install `pip3`](https://evansdianga.com/install-pip-osx/).
+
+Install the `duckietown-shell`:
+
+**Note: Never use `sudo pip install` to install `duckietown-shell`.**
+
+    $ pip3 install --no-cache-dir --user -U duckietown-shell
 
 #### Testing the Installation
 
-Typing 
+Typing
 
     $ which dts
-    
-should output the path to the `dts` executable. This path can vary based on your python setup. 
-If it is not found you may need to add something to your shell path. 
+
+should output the path to the `dts` executable. This path can vary based on your python setup.
+If it is not found you may need to add something to your shell path.
 
 ### Installation in other operating systems
 
@@ -130,14 +162,13 @@ in your `~/.bashrc` or other initialization file for a shell:
 Some functionality might not be available.
 
 
-
 ## Testing Duckietown shell
 
 At this point, try to enter the Duckietown shell by typing the command
 
     $ dts
 
-If you get an error, delete the subfolder `commands` in the folder `~/.dt-shell` 
+If you get an error, delete the subfolder `commands` in the folder `~/.dt-shell`
 
     ~/.dt-shell$ rm -rf commands/
 
@@ -147,7 +178,7 @@ Then, try again
 
 -----------------------
 
-**You now have successfully installed the Duckietown Shell. If you know what you want to do with it go ahead. Below are some examples of things you can do with the Duckietown Shell** 
+**You now have successfully installed the Duckietown Shell. If you know what you want to do with it go ahead. Below are some examples of things you can do with the Duckietown Shell**
 
 ## Compile one of the "Duckumentation"
 
@@ -163,32 +194,32 @@ There is an incremental build system. To clean and run from scratch:
 
     $ dts docs clean
     $ dts docs build
-  
+
 
 ## Authenticate a Duckietown Token
 
 Run the command `dts tok set` to set the Duckietown authentication token:
 
-    $ dts tok set  
+    $ dts tok set
 
 Instructions will guide you and you will be prompted for the token.
 
 If you already know the token, then you can use:
 
     $ dts tok set dt2-YOUR-TOKEN
-    
+
 ### Verifying that a token is valid
 
 To verify that a token is valid, you can use:
 
     $ dts tok verify dt2-TOKEN-TO-VERIFY
-    
+
 This exits with 0 if the token is valid, and writes on standard output the following json:
 
     {"uid": 3, "expiration": "2018-09-23"}
-    
+
 which means that the user is identified as uid 3 until the given expiration date.
- 
+
 
 -----------------------
 
@@ -224,8 +255,70 @@ If you want to just uninstall the duckietown-shell python module, you could do:
 
     $ python3 -m pip uninstall duckietown-shell
 
-If you also want to reset the settings, e.g. your Duckietown token, docker logins, version of the shell, etc, you would 
-also want to remove the `.duckietown/shell` folder in your home folder. 
+If you also want to reset the settings, e.g. your Duckietown token, docker logins, version of the shell, etc, you would
+also want to remove the `.duckietown/shell` folder in your home folder.
 On Ubuntu/mac for example, this could be done with:
 
     $ rm -rf ~/.duckietown/shell
+
+-----------------------
+
+## Developing Duckietown Shell
+
+Clone the Duckietown Shell repository
+
+    $ git clone git@github.com:duckietown/duckietown-shell.git
+
+### Install from Local Source
+
+You can install Duckietown Shell from your local source
+
+	$ cd duckietown-shell
+    $ pipx install -e .
+
+Note: using the `-e` option would install `dts` and link it directly to your source code. This means that any changes to the source code would reflect directly in the environment.
+
+You can also use `pip` to install
+
+    $ pip install -e .
+
+### Running & Debugging from Visual Studio Code
+
+To run the app in debug mode using Visual Studio Code, follow these steps:
+
+1. Open the Debug view by clicking on the Debug icon in the Activity Bar on the side of the window.
+2. Select the `dts` Launch configuration from the dropdown menu.
+3. Click the green play button to start debugging.
+4. Enter the arguments that you want to pass to the `dts` command, for example `profile list` -- this is the same as executing `dts profile list`.
+
+This will launch the application in debug mode, allowing you to set breakpoints and step through the code.
+
+### Developing Duckietown Shell Commands
+
+**Note**: Duckietown Shell comes with a core set of commands used to manage the Duckietown Shell environment. All Duckietown specific commands come from the Duckietown Shell Commands repository - https://github.com/duckietown/duckietown-shell-commands
+
+For Duckietown Shell Commands development, you need to tell `dts` where to find the command set.
+
+Use the env variable to work on your local copy of the commands:
+
+    export DTSHELL_COMMANDS=/path/to/my/duckietown-shell-commands
+
+For additional information, see [devel](devel.md).
+
+#### Debugging with Visual Studio Code
+
+You can set the `DTSHELL_COMMANDS` variable via the `python.env` file located under `.vscode` directory.
+
+To simplify development, you can symlink the `duckietown-shell-commands` directory/repository to be inside the `duckietown-shell` project:
+
+```sh
+# assuming that the duckietown-shell-commands repository has been cloned
+# at the same level as the duckietown-shell repo
+cd ~/duckietown-shell
+ln -s $(realpath ../duckietown-shell-commands) ./
+```
+
+Note: don't forget to set your `DTSHELL_COMMANDS` environment variable by editing the `python.env` file.
+
+This allows you to easily add breakpoints in the `duckietown-shell-commands` python files and run `dts` in debug mode.
+

--- a/lib/dt_shell/commands/commands.py
+++ b/lib/dt_shell/commands/commands.py
@@ -391,6 +391,7 @@ class CommandSet:
             stdout: str = run_cmd(["git", "-C", self.path, "rev-parse", "HEAD"])
             # noinspection PyTypeChecker
             return next(filter(len, stdout.split("\n")))
+        return None
 
     def as_dict(self) -> dict:
         return {
@@ -419,13 +420,14 @@ class CommandSet:
             # clone the repo
             branch: List[str] = ["--branch", self.repository.branch] if self.repository.branch else []
             run_cmd(["git", "clone"] + branch + ["--recurse-submodules", remote_url, self.path])
-            logger.info(f"Command set downloaded successfully!")
+            logger.info("Command set downloaded successfully!")
             # refresh commands
             self.refresh()
         except Exception as e:
             # Excepts as InvalidRemote
             logger.error(f"Unable to clone the repo at '{remote_url}':\n{str(e)}.")
             return False
+        return True
 
     def update(self) -> bool:
         # check that the repo is initialized in the commands path

--- a/lib/dt_shell/profile.py
+++ b/lib/dt_shell/profile.py
@@ -218,7 +218,7 @@ class ShellProfile:
 
         # load command sets
         if "DTSHELL_COMMANDS" in os.environ:
-            commands_path = os.environ["DTSHELL_COMMANDS"]
+            commands_path = os.path.abspath(os.environ["DTSHELL_COMMANDS"])
             # make sure the given path exists
             if not os.path.exists(commands_path):
                 msg = f"The path {commands_path} given with the environment variable DTSHELL_COMMANDS does " \

--- a/lib/dt_shell/shell.py
+++ b/lib/dt_shell/shell.py
@@ -656,7 +656,7 @@ class DTShell(Cmd):
                     raise
                 except (UserAborted, KeyboardInterrupt):
                     raise
-                except ModuleNotFoundError:
+                except ModuleNotFoundError as e:
                     lines: List[str] = []
                     cs_path: str = os.path.abspath(os.path.realpath(command_set.path))
                     # check PYTHONPATH
@@ -687,7 +687,8 @@ class DTShell(Cmd):
                         lines.append(f"\t- file[{init_fpath}] exists: {os.path.isfile(init_fpath)}")
                     # compile details
                     details: str = "\n".join(lines)
-                    msg = f"The command '{selector.replace('.', '/')}' could not be imported." \
+                    msg = f"The command '{selector.replace('.', '/')}' could not be imported.\n\n" \
+                          f"ModuleNotFoundError: {e}" \
                           f"\n\n{details}\n\n" \
                           f"{traceback.format_exc()}"
                     self._errors_loading.append(msg)

--- a/setup.py
+++ b/setup.py
@@ -74,10 +74,11 @@ setup(
     version=shell_version,
     download_url='http://github.com/duckietown/duckietown-shell/tarball/%s' % shell_version,
     package_dir={
+        '': 'lib',
         'dt_shell': 'lib/dt_shell',
         'dt_shell_cli': 'lib/dt_shell_cli',
     },
-    packages=find_packages("lib", exclude=["dt_shell_tests"]),
+    packages=find_packages(where="lib", exclude=["dt_shell_tests"]),
     # we want the python 2 version to download it, and then exit with an error
     # python_requires='>=3.6',
 


### PR DESCRIPTION
 - added how to use `pipx` to install;
 - added section on how to develop and debug
 - fixed setup.py to allow for local (editable) install
 - fixed importer to handle (and unload) module name clashes