### PR TITLE
Auto-Create Shell Profiles from Environment Variables

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 		//"DTSHELL_COMMANDS" : "", // path to the command set repository.
 		"DTSHELL_DISTRO" : "ente", // distribution to associate with the profile.
 		"DTSHELL_TOKEN": "${localEnv:DTSHELL_TOKEN}" // fallback to host env if .env.local doesn't work
-	}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -25,7 +25,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+	"postCreateCommand": "pip install -e . --break-system-packages",
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:noble",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/python:1": {}
+	},
+	"runArgs": [
+		"--env-file", "${localWorkspaceFolder}/.env.local"
+	],
+	"containerEnv": {
+		"DTSHELL_PROFILE" : "ente",		// name of the profile to use or create.
+		//"DTSHELL_COMMANDS" : "", // path to the command set repository.
+		"DTSHELL_DISTRO" : "ente", // distribution to associate with the profile.
+		"DTSHELL_TOKEN": "${localEnv:DTSHELL_TOKEN}" // fallback to host env if .env.local doesn't work
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cli
 .idea
 testing/ubuntu18/challenge-aido1_luck-template-python/
 build
+.env.local

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ Then, try again
 
 **You now have successfully installed the Duckietown Shell. If you know what you want to do with it go ahead. Below are some examples of things you can do with the Duckietown Shell**
 
+## Non-interactive setup
+
+The Duckietown Shell can be preconfigured without interactive prompts by setting a few environment variables before the first run:
+
+- `DTSHELL_PROFILE` – name of the profile to use or create.
+- `DTSHELL_COMMANDS` – path to the command set repository.
+- `DTSHELL_DISTRO` – distribution to associate with the profile.
+- `DTSHELL_TOKEN` or `DUCKIETOWN_TOKEN` – a Duckietown authentication token.
+
+With these variables exported, running `dts` will not ask for input during the initial configuration, which is useful for scripted or containerized setups.
+
 ## Compile one of the "Duckumentation"
 
 To compile one of the books (e.g. docs-duckumentation but there are many others):

--- a/lib/dt_shell/assets/requirements.txt
+++ b/lib/dt_shell/assets/requirements.txt
@@ -7,7 +7,7 @@ argcomplete>=3.1.4,<4
 coloredlogs>=15.0,<16
 filelock>=3,<4
 dockertown>=0.2.5,<1
-dtproject>=1.0.11,<2
+dtproject>=1.0.12,<2
 dt-authentication>=2.1.4,<3
 dt-data-api>=2.0.0,<3
 setuptools<67.3.0

--- a/lib/dt_shell/commands/importer.py
+++ b/lib/dt_shell/commands/importer.py
@@ -106,6 +106,18 @@ def import_configuration(command_set: CommandSet, selector: str) -> Type[DTComma
                 f"{e.version_needed}"
             )
             return default_command_configuration.DTCommandConfiguration
+        except ModuleNotFoundError as e:
+            logger.warning(
+                f"Command configuration '{_command_sel}' could not be loaded due to missing dependency: {e}. "
+                f"Using default configuration."
+            )
+            return default_command_configuration.DTCommandConfiguration
+        except Exception as e:
+            logger.warning(
+                f"Command configuration '{_command_sel}' could not be loaded: {e}. "
+                f"Using default configuration."
+            )
+            return default_command_configuration.DTCommandConfiguration
         finally:
             # restore PYTHONPATH
             sys.path = old

--- a/lib/dt_shell/commands/repository.py
+++ b/lib/dt_shell/commands/repository.py
@@ -1,4 +1,5 @@
 import json
+import os
 import traceback
 from dataclasses import dataclass
 from typing import Optional, List
@@ -103,8 +104,11 @@ class CommandsRepository:
 
     @staticmethod
     def head_tag(path: str) -> Optional[str]:
+        # Check if path exists first
+        if not os.path.exists(path):
+            return None
         try:
-            tags: str = run_cmd(["git", "-C", path, "describe", "--exact-match", "--tags", "HEAD"])
+            tags_output: Optional[str] = run_cmd(["git", "-C", path, "describe", "--exact-match", "--tags", "HEAD"])
         except RunCommandException as e:
             if e.stderr is not None and "no tag exactly matches" in e.stderr:
                 # just not an exact match
@@ -117,24 +121,29 @@ class CommandsRepository:
                 traceback.print_exc()
             return None
         # ---
-        tags: List[str] = tags.strip().split("\n")
+        if tags_output is None:
+            return None
+        tags: List[str] = tags_output.strip().split("\n")
         if not tags:
             return None
         return tags[0]
 
     @staticmethod
     def closest_tag(path: str) -> Optional[str]:
+        # Check if path exists first
+        if not os.path.exists(path):
+            return None
         try:
-            tags: Optional[str] = run_cmd(["git", "-C", path, "tag", "--merged"])
+            tags_output: Optional[str] = run_cmd(["git", "-C", path, "tag", "--merged"])
         except Exception:
             if DTShellConstants.VERBOSE:
                 traceback.print_exc()
             return None
-        # no tgs
-        if tags is None:
+        # no tags
+        if tags_output is None:
             return None
         # ---
-        tags: List[str] = tags.strip().split("\n")
+        tags: List[str] = tags_output.strip().split("\n")
         if not tags:
             return None
         return tags[-1]

--- a/lib/dt_shell/shell.py
+++ b/lib/dt_shell/shell.py
@@ -817,27 +817,33 @@ class DTShell(Cmd):
         if self._profile is None:
             if readonly:
                 raise ConfigNotPresent()
-            print()
-            print("You need to choose the distribution you want to work with.")
-            distros: List[Choice] = []
-            for distro in KNOWN_DISTRIBUTIONS.values():
-                # only show production branches
-                if distro.staging:
-                    continue
-                # only show stable distributions
-                if not distro.stable:
-                    continue
-                # ---
-                eol: str = "" if distro.end_of_life is None else f"(end of life: {distro.end_of_life_fmt})"
-                label = [("class:choice", distro.name), ("class:disabled", f"  {eol}")]
-                choice: Choice = Choice(title=label, value=distro.name)
-                if distro.name == SUGGESTED_DISTRIBUTION:
-                    distros.insert(0, choice)
-                else:
-                    distros.append(choice)
-            # let the user choose the distro
-            new_profile = questionary.select(
-                "Choose a distribution:", choices=distros, style=cli_style).unsafe_ask()
+            env_distro: Optional[str] = os.environ.get("DTSHELL_DISTRO")
+            if env_distro is not None:
+                if env_distro not in KNOWN_DISTRIBUTIONS:
+                    raise ValueError(f"Unknown distribution '{env_distro}' specified in DTSHELL_DISTRO")
+                new_profile = env_distro
+            else:
+                print()
+                print("You need to choose the distribution you want to work with.")
+                distros: List[Choice] = []
+                for distro in KNOWN_DISTRIBUTIONS.values():
+                    # only show production branches
+                    if distro.staging:
+                        continue
+                    # only show stable distributions
+                    if not distro.stable:
+                        continue
+                    # ---
+                    eol: str = "" if distro.end_of_life is None else f"(end of life: {distro.end_of_life_fmt})"
+                    label = [("class:choice", distro.name), ("class:disabled", f"  {eol}")]
+                    choice: Choice = Choice(title=label, value=distro.name)
+                    if distro.name == SUGGESTED_DISTRIBUTION:
+                        distros.insert(0, choice)
+                    else:
+                        distros.append(choice)
+                # let the user choose the distro
+                new_profile = questionary.select(
+                    "Choose a distribution:", choices=distros, style=cli_style).unsafe_ask()
             modified_config = True
 
         # make a new profile if needed

--- a/lib/dt_shell/shell.py
+++ b/lib/dt_shell/shell.py
@@ -235,10 +235,40 @@ class DTShell(Cmd):
         # custom profile
         if profile is not None:
             if profile not in self._db_profiles.keys():
-                raise UserError(f"The profile '{profile}' does not exist.")
-            logger.info(f"Using profile '{profile}' as prescribed by --profile or environment variable DTSHELL_PROFILE")
-            with self.settings.in_memory():
-                self.settings.profile = profile
+                # Auto-create profile if DTSHELL_PROFILE is set but profile doesn't exist
+                if not readonly:
+                    # Get distro from environment variable
+                    env_distro: Optional[str] = os.environ.get("DTSHELL_DISTRO")
+                    if env_distro is not None:
+                        if env_distro not in KNOWN_DISTRIBUTIONS:
+                            raise ValueError(f"Unknown distribution '{env_distro}' specified in DTSHELL_DISTRO")
+                        
+                        # Print big warning
+                        print("\n" + "=" * 80)
+                        print("🚨 AUTOMATIC PROFILE CREATION 🚨")
+                        print("=" * 80)
+                        print(f"WARNING: Profile '{profile}' does not exist!")
+                        print(f"Auto-creating profile '{profile}' with distribution '{env_distro}'")
+                        print("as specified by DTSHELL_PROFILE and DTSHELL_DISTRO environment variables.")
+                        print("=" * 80 + "\n")
+                        
+                        # Create the profile
+                        logger.info(f"Auto-creating profile '{profile}' with distribution '{env_distro}'...")
+                        new_profile = ShellProfile(name=profile, _distro=env_distro)
+                        # Set as current profile
+                        self.settings.profile = profile
+                        # Configure the profile (this will handle token setup if needed)
+                        new_profile.configure(readonly=readonly)
+                        logger.info(f"Profile '{profile}' created successfully!")
+                    else:
+                        raise UserError(f"The profile '{profile}' does not exist and DTSHELL_DISTRO is not set. "
+                                      f"Set DTSHELL_DISTRO to auto-create the profile or create it manually with 'dts profile new'.")
+                else:
+                    raise UserError(f"The profile '{profile}' does not exist.")
+            else:
+                logger.info(f"Using profile '{profile}' as prescribed by --profile or environment variable DTSHELL_PROFILE")
+                with self.settings.in_memory():
+                    self.settings.profile = profile
 
         # load current profile
         self._profile: ShellProfile = ShellProfile(self.settings.profile, readonly=readonly) \


### PR DESCRIPTION
## Summary

This PR adds automatic profile creation functionality to the Duckietown shell, allowing developers to configure and bootstrap shell environments using environment variables. When `DTSHELL_PROFILE` is set to a non-existent profile and `DTSHELL_DISTRO` is specified, the shell will automatically create the profile with a prominent warning message.

## Changes Made

### 🆕 **Auto-Profile Creation Feature**
- **Environment-driven setup**: Automatically creates profiles when `DTSHELL_PROFILE` and `DTSHELL_DISTRO` environment variables are set
- **User-friendly warnings**: Displays a prominent warning banner when auto-creating profiles to inform users
- **Token integration**: Automatically uses `DTSHELL_TOKEN` from environment variables if available
- **Error handling**: Clear error messages for invalid distributions or missing required environment variables

### 🔧 **Technical Fixes**
- **Repository safety checks**: Added path existence validation in `CommandsRepository.head_tag()` and `CommandsRepository.closest_tag()` to prevent git command failures on non-existent directories
- **Import error handling**: Added graceful handling for missing command configuration dependencies to prevent shell crashes

### ⚙️ **DevContainer Integration**
- **Pre-configured environment**: Updated `.devcontainer/devcontainer.json` with environment variables for seamless development setup
- **Secret token support**: Uses `.env.local` file for secure token storage (not tracked in git)

## Testing Instructions

### 1. **Test Auto-Profile Creation in DevContainer**

The devcontainer is pre-configured to demonstrate this feature:

```bash
# Open this repository in VS Code with Dev Containers extension
# The devcontainer will automatically:
# - Load environment variables from .env.local
# - Set DTSHELL_PROFILE=ente and DTSHELL_DISTRO=ente
# - Auto-create the profile on first shell run

# Test the shell
dts --help
```

You should see a prominent warning message about auto-creating the 'ente' profile.

### 2. **Manual Testing with Custom Profiles**

```bash
# Test creating a custom profile
export DTSHELL_PROFILE="test-profile"
export DTSHELL_DISTRO="daffy"  # or another valid distribution
export DTSHELL_TOKEN="your-token-here"

# Run the shell - it should auto-create the profile
dts --help
```

### 3. **Test Error Handling**

```bash
# Test invalid distribution
export DTSHELL_PROFILE="test-profile"
export DTSHELL_DISTRO="invalid-distro"
dts --help  # Should show clear error message

# Test missing DTSHELL_DISTRO
export DTSHELL_PROFILE="test-profile"
unset DTSHELL_DISTRO
dts --help  # Should show helpful error message
```

### 4. **Test Environment File Setup**

Create a `.env.local` file for secure token storage:

```bash
# Create .env.local (this file is gitignored)
echo "DTSHELL_TOKEN=your-secret-token-here" > .env.local

# The devcontainer will automatically load this file
# Rebuild the container to test:
# Ctrl+Shift+P -> "Dev Containers: Rebuild Container"
```

### 5. **Verify Profile Structure**

After auto-creation, check that the profile was properly created:

```bash
# Check profile directory structure
ls -la ~/.duckietown/shell/profiles/ente/
# Should show: commands/, shell.yaml

# Verify profile is active
dts --help | grep "Profile:"
# Should show: Profile: ente
```

### 6. **DevContainer-Specific Testing**

Since this workspace runs in an Ubuntu 24.04.2 LTS dev container with pre-installed tools:

```bash
# Verify container environment
echo "Container OS: $(lsb_release -d)"
echo "Python version: $(python3 --version)"
echo "Git version: $(git --version)"
echo "Docker available: $(docker --version)"

# Test profile creation with container tools
tree ~/.duckietown/shell/profiles/ente/ 2>/dev/null || find ~/.duckietown/shell/profiles/ente/ -type f

# Check environment variables are loaded correctly
env | grep DTSHELL
```

## Benefits

- **Streamlined onboarding**: New developers can start working immediately without manual profile setup
- **Consistent environments**: Teams can share standardized shell configurations
- **DevContainer ready**: Perfect for containerized development workflows with Ubuntu 24.04.2 LTS
- **Secure token handling**: Environment variable-based token management prevents accidental commits
- **Tool integration**: Works seamlessly with pre-installed development tools (Git, Docker, Python)

## Breaking Changes

None. This feature is additive and maintains full backward compatibility with existing workflows.

## DevContainer Configuration

The `.devcontainer/devcontainer.json` has been updated with:

```jsonc
{
  "runArgs": [
    "--env-file", "${localWorkspaceFolder}/.env.local"
  ],
  "containerEnv": {
    "DTSHELL_PROFILE": "ente",
    "DTSHELL_DISTRO": "ente", 
    "DTSHELL_TOKEN": "${localEnv:DTSHELL_TOKEN}"
  },
  "postCreateCommand": "pip install -e . --break-system-packages"
}
```

This ensures the shell is automatically configured and ready to use upon container creation.