### PR TITLE
Set `ente` distro as stable - DTSW-7086

### DIFF
--- a/lib/dt_shell/constants.py
+++ b/lib/dt_shell/constants.py
@@ -78,14 +78,14 @@ KNOWN_DISTRIBUTIONS: Dict[str, Distro] = {
     "ente": Distro(
         "ente",
         "ente",
-        stable=False,
+        stable=True,
         tokens_supported=["dt2"],
         token_preferred="dt2"
     ),
     "ente-staging": Distro(
         "ente",
         "ente-staging",
-        stable=False,
+        stable=True,
         staging=True,
         tokens_supported=["dt2"],
         token_preferred="dt2"


### PR DESCRIPTION
This PR promotes the `ente` distro from unstable to stable, allowing the user to create a new profile without the need to use the `--unstable` flag.