### PR TITLE
Set suggested distribution to `ente`

### DIFF
--- a/lib/dt_shell/constants.py
+++ b/lib/dt_shell/constants.py
@@ -91,7 +91,7 @@ KNOWN_DISTRIBUTIONS: Dict[str, Distro] = {
         token_preferred="dt2"
     ),
 }
-SUGGESTED_DISTRIBUTION: str = "daffy"
+SUGGESTED_DISTRIBUTION: str = "ente"
 
 # command set
 EMBEDDED_COMMAND_SET_NAME: str = "embedded"


### PR DESCRIPTION
This PR sets the suggested distribution to `ente, officially marking the release of the `ente` distribution.