### PR TITLE
DTSW-7225-Update-setup.py-to-require-Python-3.10-for-dts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ def get_version(filename):
     return version
 
 
-if sys.version_info < (3, 6):
-    msg = 'duckietown-shell works with Python 3.6 and later.\nDetected %s.' % str(sys.version)
+if sys.version_info < (3, 10):
+    msg = 'duckietown-shell works with Python 3.10 and later.\nDetected %s.' % str(sys.version)
     sys.exit(msg)
 
 distro = 'daffy'
@@ -81,7 +81,7 @@ setup(
     },
     packages=find_packages(where="lib", exclude=["dt_shell_tests"]),
     # we want the python 2 version to download it, and then exit with an error
-    # python_requires='>=3.6',
+    # python_requires='>=3.10',
 
     tests_require=[],
     install_requires=install_requires,


### PR DESCRIPTION
This pull request updates the minimum required Python version for the `duckietown-shell` project from 3.6 to 3.10. This ensures that the shell will only run on Python 3.10 and later, and informs users with older Python versions that they need to upgrade.

Python version requirement updates:

* Updated the version check in `setup.py` to require Python 3.10 or later, and changed the error message to reflect this new requirement.
* Updated the commented `python_requires` field in `setup.py` to indicate the new minimum version as 3.10.