### PR TITLE
DTSW-7248-Investigate-and-resolve-dts-command-error-on-Ubuntu-24.04.3

### DIFF
--- a/lib/dt_shell/environments.py
+++ b/lib/dt_shell/environments.py
@@ -14,7 +14,7 @@ from .exceptions import ShellInitException, InvalidEnvironment, CommandsLoadingE
 from .constants import SHELL_LIB_DIR, SHELL_REQUIREMENTS_LIST, DTShellConstants
 from .database.utils import InstalledDependenciesDatabase
 from .logging import dts_print
-from .utils import install_pip, pip_install, replace_spaces, print_debug_info, pretty_json
+from .utils import install_pip_tool, pip_install, replace_spaces, print_debug_info, pretty_json
 
 
 class ShellCommandEnvironmentAbs(metaclass=ABCMeta):
@@ -110,7 +110,7 @@ class VirtualPython3Environment(ShellCommandEnvironmentAbs):
                 with_pip=False,
                 prompt="dts"
             )
-            install_pip(interpreter_fpath)
+            install_pip_tool(interpreter_fpath)
 
         # install dependencies
         cache: InstalledDependenciesDatabase = InstalledDependenciesDatabase.load(shell.profile)

--- a/lib/dt_shell/utils.py
+++ b/lib/dt_shell/utils.py
@@ -236,7 +236,7 @@ class DebugInfo:
     name2versions: Dict[str, Union[str, Dict[str, str]]] = {}
 
 
-def install_pip(interpreter: str):
+def install_pip_tool(interpreter: str):
     get_pip_fpath: str = os.path.join(SHELL_LIB_DIR, "assets", "get-pip.py")
     if not os.path.exists(get_pip_fpath):
         msg = f"Required file for pip installation not found: {get_pip_fpath}"
@@ -265,7 +265,7 @@ def pip_install(interpreter: str, requirements: str):
             if attempt == MAX_PIP_INSTALL_ATTEMPTS - 1 or "No module named pip" not in error:
                 msg: str = "An error occurred while installing python dependencies"
                 raise ShellInitException(msg, stdout=e.stdout, stderr=e.stderr)
-            install_pip(interpreter)
+            install_pip_tool(interpreter)
 
 
 def indent_block(s: str, indent_len: int = 4) -> str:


### PR DESCRIPTION
This pull request refactors how `pip` is installed in virtual environments and improves the reliability of dependency installation. The main changes include moving the `pip` installation logic into a reusable function, updating the environment setup code to use this new function, and enhancing the `pip_install` function to automatically install `pip` if it's missing.

**Refactoring and reliability improvements:**

* Added a new `install_pip` function in `utils.py` to encapsulate the logic for installing `pip` using `get-pip.py`, including error handling for missing files or installation failures.
* Updated the environment setup in `environments.py` to use the new `install_pip` function instead of duplicating the installation logic.
* Improved the `pip_install` function to retry installation up to two times, automatically attempting to install `pip` if the error "No module named pip" is encountered. [[1]](diffhunk://#diff-d1142e05d97f2638fef7d7a04c97c9348977544c21da25df1a8a8a7a0b1c27abR30) [[2]](diffhunk://#diff-d1142e05d97f2638fef7d7a04c97c9348977544c21da25df1a8a8a7a0b1c27abR239-R268)
* Updated imports in `environments.py` to bring in the new `install_pip` function.