### PR TITLE
DTSW-7835 Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,6 +10,9 @@ on:
         description: "Existing release tag (e.g., v1.2.3)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/duckietown-shell/security/code-scanning/2](https://github.com/duckietown/duckietown-shell/security/code-scanning/2)

Add an explicit `permissions` block to the workflow (best at root level here, since there is only one job) with least privilege required. For this pipeline, `actions/checkout` needs `contents: read`; no write permissions are required for publishing to PyPI because that uses `TWINE_*` secrets, not `GITHUB_TOKEN`.

**File to change:** `.github/workflows/python-publish.yml`  
**Region:** near the top-level keys (`name`, `on`, `jobs`)  
**Change:** insert:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
