### PR TITLE
DTSW-7835 Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jira-pr-check.yml
+++ b/.github/workflows/jira-pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-jira-key:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/duckietown-shell/security/code-scanning/1](https://github.com/duckietown/duckietown-shell/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: set workflow-level `permissions` to read-only (`contents: read`) since this job only inspects event payload fields and does not need write access.

**File to change:** `.github/workflows/jira-pr-check.yml`  
**Region:** after `on:` trigger block and before `jobs:`.  
No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
