### PR TITLE
DTSW-7876-Address-the-pkg_resources-is-deprecated-as-an-API-Duckietown-Shell-warning

### DIFF
--- a/lib/dt_shell/assets/requirements.txt
+++ b/lib/dt_shell/assets/requirements.txt
@@ -1,7 +1,7 @@
 termcolor>=2.3.0,<3
 requests>=2.31.0,<3
 pyyaml!=6.0.0,!=5.4.0,!=5.4.1,<7
-pyfiglet>=0.8.0,<1
+pyfiglet>=1.0.4,<2
 questionary>=2.0.1,<3
 argcomplete>=3.1.4,<4
 coloredlogs>=15.0,<16

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ shell_requires = [
     "pyyaml!=6.0.0,!=5.4.0,!=5.4.1,<7",
 
     # CLI utils
-    "pyfiglet>=0.8.0,<1",
+    "pyfiglet>=1.0.4,<2",
     "questionary>=2.0.1,<3",
     "argcomplete>=3.1.4,<4",
     "coloredlogs>=15.0,<16",


### PR DESCRIPTION
This pull request updates the required version of the `pyfiglet` library to ensure compatibility and access to newer features. The version constraint is increased from `>=0.8.0,<1` to `>=1.0.4,<2` in both `requirements.txt` and `setup.py`.

Dependency version updates:

* Updated `pyfiglet` dependency version to `>=1.0.4,<2` in both `lib/dt_shell/assets/requirements.txt` and `setup.py` to ensure the use of the latest compatible major version. [[1]](diffhunk://#diff-871132da2e12d22dd40c85e0d9cd15eb545a57fce902c344d7748c74e1e6335aL4-R4) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L39-R39)